### PR TITLE
replace bigint with uint for 10x speedup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,6 +487,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,6 +584,7 @@ dependencies = [
 name = "mimc-fast"
 version = "0.1.0"
 dependencies = [
+ "itertools",
  "lazy_static",
  "rayon",
  "rocket",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,16 +98,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
-name = "bigint"
-version = "4.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0e8c8a600052b52482eff2cf4d810e462fdff1f656ac1ecb6232132a1ed7def"
-dependencies = [
- "byteorder",
- "crunchy",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,9 +216,9 @@ dependencies = [
 
 [[package]]
 name = "crunchy"
-version = "0.1.6"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2f4a431c5c9f662e1200b7c7f02c34e91361150e382089a8f2dec3ba680cbda"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-mac"
@@ -585,13 +575,13 @@ dependencies = [
 name = "mimc-fast"
 version = "0.1.0"
 dependencies = [
- "bigint",
  "lazy_static",
  "rayon",
  "rocket",
  "rocket_contrib",
  "rocket_cors",
  "serde",
+ "uint",
 ]
 
 [[package]]
@@ -950,6 +940,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1038,6 +1034,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7345c971d1ef21ffdbd103a75990a15eb03604fc8b8852ca8cb418ee1a099028"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "subtle"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1123,6 +1125,18 @@ name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+
+[[package]]
+name = "uint"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9db035e67dfaf7edd9aebfe8676afcd63eed53c8a4044fed514c8cccf1835177"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "rustc-hex",
+ "static_assertions",
+]
 
 [[package]]
 name = "unicase"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ rocket_contrib = "0.4.5"
 rocket_cors = "0.5.1"
 serde = { version = "1.0.116", features = ["derive"] }
 rayon = "1.1"
+itertools = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 lazy_static = "1.4.0"
-bigint = "4.4.3"
+uint = "0.8.5"
 rocket = "0.4.5"
 rocket_contrib = "0.4.5"
 rocket_cors = "0.5.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,12 @@ extern crate rocket;
 #[macro_use]
 extern crate lazy_static;
 
-use bigint::U512;
+use uint::construct_uint;
+construct_uint! {
+    pub struct U512(8);
+}
+use std::ops::Div;
+use std::ops::Rem;
 
 use serde::{Serialize, Deserialize};
 use rocket_contrib::json::Json;
@@ -257,15 +262,14 @@ impl PrimeElem {
     fn plus(&self, rhs: &PrimeElem) -> PrimeElem {
         let (sum, overflowed) = self.x.overflowing_add(rhs.x);
         assert!(!overflowed);
-        let (res, overflowed) = sum.overflowing_rem(*P);
-        assert!(!overflowed);
+        let res = sum.rem(*P);
         PrimeElem { x: res }
     }
 
     fn times(&self, rhs: &PrimeElem) -> PrimeElem {
         let (prod, overflowed) = self.x.overflowing_mul(rhs.x);
         assert!(!overflowed);
-        let (res, overflowed) = prod.overflowing_rem(*P);
+        let res  = prod.rem(*P);
         assert!(!overflowed);
         PrimeElem { x: res }
     }
@@ -380,8 +384,7 @@ fn mine(task: Json<Task>) -> Json<Response> {
     let y = task.chunkFootprint.bottomLeft.y;
     let size = task.chunkFootprint.sideLength;
 
-    let (threshold, overflowed) = P.overflowing_div(U512::from(task.planetRarity));
-    assert!(!overflowed);
+    let threshold = P.div(U512::from(task.planetRarity));
 
     let planets = (x..(x + size)).into_par_iter().map(|xi| {
         let mut planets = Vec::new();


### PR DESCRIPTION
Flamegraphing showed bigint to be problematic. It turns out its deprecated and the community is using uint. It provides a ~10x speedup  I got 1-2k hashes on a raspberry pi 4 and ~8k on a low end Dell XPS laptop (game not running ~5k with game taking threads). But Digital ocean 24cpu pulled ~28k hashes when benchmarked it.